### PR TITLE
add extensionKind entry in packages.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,9 @@
     "activationEvents": [
         "*"
     ],
+    "extensionKind": [
+        "ui"
+    ],
     "main": "./out/extension",
     "contributes": {
         "commands": [


### PR DESCRIPTION
This will make vscode install the extension on the client side when working with remote workspaces.