### PR TITLE
Make display name of position (currently "Pos") configurable.

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ I had been using the [Positions](https://github.com/Silvenga/vscode-positions) e
 
 ## Features
 
-- Shows cursor character offset as 'Pos \<position>' in the status bar.
+- Shows cursor character offset as 'Pos \<position>' (name configurable through 'Position Name' settings in Settings > Extensions > vscode-position) in the status bar.
 - Click the status bar or use the `Go To Position` palette command to move the cursor by offset.
 - New position is previewed while typing it in (similar to goto line)
 - Cursor and selection restored if setting position is abandoned with <kbd>esc</kbd>

--- a/package.json
+++ b/package.json
@@ -39,7 +39,17 @@
                 "mac": "ctrl+cmd+g",
                 "when": "editorTextFocus"
             }
-        ]
+        ],
+        "configuration": {
+            "title": "vscode-position",
+            "properties": {
+                "vscode-position.positionName": {
+                    "type": "string",
+                    "default": "Pos",
+                    "description": "Display name of position on status bar."
+                }
+            }
+        }
     },
     "scripts": {
         "build": "npm run compile-web",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -35,6 +35,7 @@ function getOptionalNumber(numberAsString ?: string): [number | undefined, boole
 class PositionController {
     private disposable: vscode.Disposable;
     private statusBarItem: vscode.StatusBarItem;
+    private positionName: string;
 
     constructor() {
         this.statusBarItem = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Right, 100);
@@ -81,7 +82,8 @@ class PositionController {
 
         if (offset !== undefined) {
             // Update the status bar
-            this.statusBarItem.text = `Pos ${offset}`;
+            let positionName = vscode.workspace.getConfiguration('vscode-position').positionName || 'Pos';
+            this.statusBarItem.text = `${positionName} ${offset}`;
             this.statusBarItem.show();
         }
     }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -35,7 +35,6 @@ function getOptionalNumber(numberAsString ?: string): [number | undefined, boole
 class PositionController {
     private disposable: vscode.Disposable;
     private statusBarItem: vscode.StatusBarItem;
-    private positionName: string;
 
     constructor() {
         this.statusBarItem = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Right, 100);


### PR DESCRIPTION
I'd like to have the display name of position on status bar to be "Offset" rather than "Pos". As this is purely a personal preference that not everyone would agree, I made the text configurable for users in VSCode settings. And the default name "Pos" is preserved.

Please consider give others this choice too.
(someone may like "Position" or "Position: ")